### PR TITLE
Fix translation to remove filter

### DIFF
--- a/nl_NL.csv
+++ b/nl_NL.csv
@@ -7966,7 +7966,7 @@ e.g. var/export, var/import, var/export/some/dir","Gebruik het relatieve pad naa
 "Now Shopping by","Huidige filters",module,Magento_LayeredNavigation
 "Previous","Vorige",module,Magento_LayeredNavigation
 "Remove","Verwijder",module,Magento_LayeredNavigation
-"Remove This Item","Verwijder dit artikel",module,Magento_LayeredNavigation
+"Remove This Item","Verwijder dit filter",module,Magento_LayeredNavigation
 "Shop By","Filteren",module,Magento_LayeredNavigation
 "Clear All","Alles wissen",module,Magento_LayeredNavigation
 "Shopping Options","Selectie verfijnen",module,Magento_LayeredNavigation


### PR DESCRIPTION
In the layered navigation "Remove This Item" is translated with "Verwijder dit artikel" which is incorrect. We're not removing a product, we're removing an active filter. This should be translated with "Verwijder dit filter" as suggested in this PR.